### PR TITLE
Add Custom Fields V2

### DIFF
--- a/src/CustomFields/AbstractCustomFieldsModel.php
+++ b/src/CustomFields/AbstractCustomFieldsModel.php
@@ -5,61 +5,8 @@ namespace Canvas\CustomFields;
 
 use Baka\Contracts\CustomFields\CustomFieldsTrait;
 use Canvas\Models\AbstractModel;
-use Canvas\Models\CustomFieldsModules;
-use PDO;
 
 abstract class AbstractCustomFieldsModel extends AbstractModel
 {
     use CustomFieldsTrait;
-
-    /**
-     * Get all custom fields of the given object.
-     *
-     * @param  array  $fields
-     *
-     * @return array
-     */
-    public function getAllCustomFields(array $fields = [])
-    {
-        //no di? ok so no custom fields
-        if (!$this->di->has('userData')) {
-            return ;
-        }
-
-        //We does it only find names in plural? We need to fix this or make a workaround
-        if (!$models = CustomFieldsModules::findFirstByName($this->getSource())) {
-            return;
-        }
-
-        $bind = [$this->getId(), $this->di->getApp()->getId(), $models->getId(), $this->di->getUserData()->currentCompanyId()];
-
-        // $customFieldsValueTable = $this->getSource() . '_custom_fields';
-        $customFieldsValueTable = $this->getSource() . '_custom_fields';
-
-        //We are to make a new query to replace old Canvas implementation.
-        $result = $this->getReadConnection()->prepare("SELECT l.{$this->getSource()}_id,
-                                               c.id as field_id,
-                                               c.name,
-                                               l.value ,
-                                               c.users_id,
-                                               l.created_at,
-                                               l.updated_at
-                                        FROM {$customFieldsValueTable} l,
-                                             custom_fields c
-                                        WHERE c.id = l.custom_fields_id
-                                          AND l.{$this->getSource()}_id = ?
-                                          AND c.apps_id = ?
-                                          AND c.custom_fields_modules_id = ?
-                                          AND c.companies_id = ? ");
-
-        $result->execute($bind);
-
-        $listOfCustomFields = [];
-
-        while ($row = $result->fetch(PDO::FETCH_OBJ)) {
-            $listOfCustomFields[$row->name] = $row->value;
-        }
-
-        return $listOfCustomFields;
-    }
 }

--- a/src/CustomFields/AbstractCustomFieldsModel.php
+++ b/src/CustomFields/AbstractCustomFieldsModel.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Canvas\CustomFields;
 
-use Canvas\Models\CustomFieldsModules;
-use Canvas\Models\AbstractModel;
 use Baka\Contracts\CustomFields\CustomFieldsTrait;
+use Canvas\Models\AbstractModel;
+use Canvas\Models\CustomFieldsModules;
 use PDO;
 
 abstract class AbstractCustomFieldsModel extends AbstractModel
@@ -16,6 +16,7 @@ abstract class AbstractCustomFieldsModel extends AbstractModel
      * Get all custom fields of the given object.
      *
      * @param  array  $fields
+     *
      * @return array
      */
     public function getAllCustomFields(array $fields = [])

--- a/src/Models/Companies.php
+++ b/src/Models/Companies.php
@@ -301,8 +301,6 @@ class Companies extends AbstractModel
      */
     public function afterCreate()
     {
-        parent::afterCreate();
-
         $this->fire('company:afterSignup', $this);
     }
 

--- a/src/Models/Companies.php
+++ b/src/Models/Companies.php
@@ -16,7 +16,7 @@ use Phalcon\Di;
 use Phalcon\Validation;
 use Phalcon\Validation\Validator\PresenceOf;
 
-class Companies extends \Canvas\CustomFields\AbstractCustomFieldsModel
+class Companies extends AbstractModel
 {
     use HashTableTrait;
     use UsersAssociatedTrait;

--- a/src/Models/FileSystem.php
+++ b/src/Models/FileSystem.php
@@ -9,7 +9,6 @@ use Baka\Http\Exception\NotFoundException;
 use Exception;
 use Phalcon\Di;
 
-
 class FileSystem extends AbstractModel
 {
     use HashTableTrait;

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -29,7 +29,7 @@ class Subscription extends BakaSubscription
     public int $user_id;
     public int $companies_id;
     public int $apps_id;
-    public string $name;
+    public ?string $name = null;
     public string $stripe_id;
     public string $stripe_plan;
     public int $quantity;

--- a/src/Models/SystemModules.php
+++ b/src/Models/SystemModules.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Canvas\Models;
 
+use Baka\Contracts\CustomFields\CustomFieldsTrait;
 use Baka\Database\SystemModules as BakaSystemModules;
 use Baka\Http\Exception\InternalServerErrorException;
 use Phalcon\Di;
@@ -10,6 +11,8 @@ use Phalcon\Mvc\ModelInterface;
 
 class SystemModules extends BakaSystemModules
 {
+    use CustomFieldsTrait;
+    
     /**
      * Initialize method for model.
      */

--- a/src/Models/UserCompanyApps.php
+++ b/src/Models/UserCompanyApps.php
@@ -9,8 +9,8 @@ class UserCompanyApps extends \Baka\Auth\Models\UserCompanyApps
 {
     public int $companies_id;
     public int $apps_id;
-    public string $stripe_id;
-    public int $subscriptions_id;
+    public ?string $stripe_id = null;
+    public ?int $subscriptions_id = 0;
 
     /**
      * Initialize method for model.

--- a/src/Providers/ModelsCacheProvider.php
+++ b/src/Providers/ModelsCacheProvider.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Canvas\Providers;
 
+use Baka\Constants\Flags;
 use function Baka\envValue;
-
-use Canvas\Constants\Flags;
-use Phalcon\Cache\Backend\Memory;
-use Phalcon\Cache\Backend\Redis;
-use Phalcon\Cache\Frontend\Data;
-use Phalcon\Cache\Frontend\None;
+use Phalcon\Cache;
+use Phalcon\Cache\AdapterFactory;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\ServiceProviderInterface;
+use Phalcon\Storage\SerializerFactory;
 
 class ModelsCacheProvider implements ServiceProviderInterface
 {
@@ -21,30 +19,32 @@ class ModelsCacheProvider implements ServiceProviderInterface
      */
     public function register(DiInterface $container) : void
     {
-        $config = $container->get('config');
+        $config = $container->getShared('config');
+        $app = envValue('GEWAER_APP_ID', 1);
 
         $container->setShared(
             'modelsCache',
-            function () use ($config) {
+            function () use ($config, $app) {
+                $type = 'redis';
                 if (strtolower($config->app->env) != Flags::PRODUCTION) {
-                    $frontCache = new None();
-                    $cache = new Memory($frontCache);
-                } else {
-                    $frontCache = new Data([
-                        'lifetime' => envValue('MODELS_CACHE_LIFETIME', 86400),
-                    ]);
-
-                    $cache = new Redis(
-                        $frontCache,
-                        [
-                            'host' => envValue('REDIS_HOST', '127.0.0.1'),
-                            'port' => envValue('REDIS_PORT', 6379),
-                            'prefix' => 'modelsCache',
-                        ]
-                    );
+                    $type = 'memory';
                 }
 
-                return $cache;
+                $serializerFactory = new SerializerFactory();
+                $adapterFactory = new AdapterFactory($serializerFactory);
+
+                $options = [
+                    'defaultSerializer' => 'php',
+                    'lifetime' => 7200
+                ];
+
+                $cache = $config->get('cache')->toArray();
+                $options = $cache['metadata']['prod']['options'];
+                $options['prefix'] = $app;
+
+                $adapter = $adapterFactory->newInstance($type, $options);
+
+                return new Cache($adapter);
             }
         );
     }

--- a/src/Providers/ModelsCacheProvider.php
+++ b/src/Providers/ModelsCacheProvider.php
@@ -25,34 +25,16 @@ class ModelsCacheProvider implements ServiceProviderInterface
         $container->setShared(
             'modelsCache',
             function () use ($config, $app) {
-                
                 $type = 'redis';
-<<<<<<< HEAD
                 if (strtolower($config->app->env) != Flags::PRODUCTION) {
                     $type = 'memory';
-=======
-                $cache = $config->get('cache')->toArray();
-                $options = $cache['metadata']['prod']['options'];
-
-                if (strtolower($config->app->env) != Flags::PRODUCTION) {
-                    $type = 'memory';
-                    $options = $cache['metadata']['dev']['options'];
->>>>>>> 68a046b8acb7a29f78a51afa18548a879e0832dd
                 }
 
                 $serializerFactory = new SerializerFactory();
                 $adapterFactory = new AdapterFactory($serializerFactory);
 
-<<<<<<< HEAD
-                $options = [
-                    'defaultSerializer' => 'php',
-                    'lifetime' => 7200
-                ];
-
                 $cache = $config->get('cache')->toArray();
                 $options = $cache['metadata']['prod']['options'];
-=======
->>>>>>> 68a046b8acb7a29f78a51afa18548a879e0832dd
                 $options['prefix'] = $app;
 
                 $adapter = $adapterFactory->newInstance($type, $options);

--- a/src/Providers/ModelsCacheProvider.php
+++ b/src/Providers/ModelsCacheProvider.php
@@ -25,6 +25,7 @@ class ModelsCacheProvider implements ServiceProviderInterface
         $container->setShared(
             'modelsCache',
             function () use ($config, $app) {
+                
                 $type = 'redis';
                 $cache = $config->get('cache')->toArray();
                 $options = $cache['metadata']['prod']['options'];

--- a/src/Providers/ModelsCacheProvider.php
+++ b/src/Providers/ModelsCacheProvider.php
@@ -26,15 +26,17 @@ class ModelsCacheProvider implements ServiceProviderInterface
             'modelsCache',
             function () use ($config, $app) {
                 $type = 'redis';
+                $cache = $config->get('cache')->toArray();
+                $options = $cache['metadata']['prod']['options'];
+                
                 if (strtolower($config->app->env) != Flags::PRODUCTION) {
                     $type = 'memory';
+                    $options = $cache['metadata']['dev']['options'];
                 }
 
                 $serializerFactory = new SerializerFactory();
                 $adapterFactory = new AdapterFactory($serializerFactory);
 
-                $cache = $config->get('cache')->toArray();
-                $options = $cache['metadata']['prod']['options'];
                 $options['prefix'] = $app;
 
                 $adapter = $adapterFactory->newInstance($type, $options);

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -1,0 +1,305 @@
+<?php
+
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class AddAppCustomFields extends Phinx\Migration\AbstractMigration
+{
+    public function change()
+    {
+        $this->table('apps_keys', [
+            'id' => false,
+            'primary_key' => ['apps_id', 'users_id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['client_secret_id'], [
+                'name' => 'client_secret_id',
+                'unique' => false,
+            ])
+            ->addIndex(['client_id'], [
+                'name' => 'client_id',
+                'unique' => false,
+            ])
+            ->addIndex(['last_used_date'], [
+                'name' => 'last_used_date',
+                'unique' => false,
+            ])
+            ->addIndex(['client_id', 'apps_id'], [
+                'name' => 'client_id_apps_id',
+                'unique' => false,
+            ])
+            ->addIndex(['client_secret_id', 'apps_id'], [
+                'name' => 'client_secret_id_apps_id',
+                'unique' => false,
+            ])
+            ->save();
+        $this->table('custom_fields_modules', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['apps_id'], [
+                'name' => 'apps_id',
+                'unique' => false,
+            ])
+            ->addIndex(['name'], [
+                'name' => 'name',
+                'unique' => false,
+            ])
+            ->addIndex(['model_name'], [
+                'name' => 'model_name',
+                'unique' => false,
+            ])
+            ->addIndex(['apps_id', 'name', 'model_name'], [
+                'name' => 'apps_id_name_model_name',
+                'unique' => false,
+            ])
+            ->addIndex(['apps_id', 'name', 'model_name', 'is_deleted'], [
+                'name' => 'apps_id_name_model_name_is_deleted',
+                'unique' => false,
+            ])
+            ->addIndex(['apps_id', 'model_name', 'is_deleted'], [
+                'name' => 'apps_id_model_name_is_deleted',
+                'unique' => false,
+            ])
+            ->save();
+        $this->table('countries', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addColumn('code', 'string', [
+                'null' => false,
+                'limit' => 128,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'name',
+            ])
+            ->changeColumn('flag', 'string', [
+                'null' => true,
+                'default' => null,
+                'limit' => 128,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'code',
+            ])
+            ->changeColumn('created_at', 'datetime', [
+                'null' => false,
+                'after' => 'flag',
+            ])
+            ->changeColumn('updated_at', 'datetime', [
+                'null' => true,
+                'default' => null,
+                'after' => 'created_at',
+            ])
+            ->changeColumn('is_deleted', 'integer', [
+                'null' => false,
+                'default' => '0',
+                'limit' => '3',
+                'after' => 'updated_at',
+            ])
+            ->save();
+        $this->table('apps_custom_fields', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addColumn('id', 'biginteger', [
+                'null' => false,
+                'limit' => MysqlAdapter::INT_BIG,
+                'identity' => 'enable',
+            ])
+            ->addColumn('companies_id', 'integer', [
+                'null' => false,
+                'limit' => MysqlAdapter::INT_REGULAR,
+                'after' => 'id',
+            ])
+            ->addColumn('users_id', 'integer', [
+                'null' => false,
+                'limit' => MysqlAdapter::INT_REGULAR,
+                'after' => 'companies_id',
+            ])
+            ->addColumn('model_name', 'string', [
+                'null' => false,
+                'limit' => 255,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'users_id',
+            ])
+            ->addColumn('entity_id', 'biginteger', [
+                'null' => false,
+                'default' => '0',
+                'limit' => MysqlAdapter::INT_BIG,
+                'after' => 'model_name',
+            ])
+            ->addColumn('name', 'string', [
+                'null' => false,
+                'limit' => 255,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'entity_id',
+            ])
+            ->addColumn('label', 'string', [
+                'null' => false,
+                'limit' => 255,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'name',
+            ])
+            ->addColumn('value', 'text', [
+                'null' => true,
+                'default' => null,
+                'limit' => MysqlAdapter::TEXT_LONG,
+                'collation' => 'utf8mb4_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'after' => 'label',
+            ])
+            ->addColumn('created_at', 'datetime', [
+                'null' => false,
+                'after' => 'value',
+            ])
+            ->addColumn('updated_at', 'datetime', [
+                'null' => true,
+                'default' => null,
+                'after' => 'created_at',
+            ])
+            ->addColumn('is_deleted', 'integer', [
+                'null' => false,
+                'default' => '0',
+                'limit' => MysqlAdapter::INT_TINY,
+                'after' => 'updated_at',
+            ])
+            ->addIndex(['companies_id'], [
+                'name' => 'companies_id',
+                'unique' => false,
+            ])
+            ->addIndex(['users_id'], [
+                'name' => 'users_id',
+                'unique' => false,
+            ])
+            ->addIndex(['model_name'], [
+                'name' => 'model_name',
+                'unique' => false,
+            ])
+            ->addIndex(['entity_id'], [
+                'name' => 'entity_id',
+                'unique' => false,
+            ])
+            ->addIndex(['name'], [
+                'name' => 'name',
+                'unique' => false,
+            ])
+            ->addIndex(['label'], [
+                'name' => 'label',
+                'unique' => false,
+            ])
+            ->addIndex(['companies_id', 'model_name', 'entity_id'], [
+                'name' => 'companies_id_model_name_entity_id',
+                'unique' => false,
+            ])
+            ->addIndex(['model_name', 'entity_id'], [
+                'name' => 'model_name_2',
+                'unique' => false,
+            ])
+            ->addIndex(['model_name', 'entity_id', 'name'], [
+                'name' => 'model_name_3',
+                'unique' => false,
+            ])
+            ->addIndex(['created_at'], [
+                'name' => 'created_at',
+                'unique' => false,
+            ])
+            ->addIndex(['updated_at'], [
+                'name' => 'updated_at',
+                'unique' => false,
+            ])
+            ->addIndex(['is_deleted'], [
+                'name' => 'is_deleted',
+                'unique' => false,
+            ])
+            ->addIndex(['companies_id', 'model_name', 'entity_id', 'name'], [
+                'name' => 'companies_id_model_name_entity_id_name',
+                'unique' => false,
+            ])
+            ->create();
+
+        $this->table('custom_fields_values', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['custom_fields_id'], [
+                'name' => 'custom_fields_id_entity_id_custom_fields_modules_id',
+                'unique' => false,
+            ])
+            ->addIndex(['custom_fields_id', 'is_default'], [
+                'name' => 'custom_fields_id_entity_id_custom_fields_modules_id_is_default',
+                'unique' => false,
+            ])
+            ->save();
+
+        $this->table('resources', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['apps_id'], [
+                'name' => 'apps_id',
+                'unique' => false,
+            ])
+            ->save();
+
+        $this->table('user_roles', [
+            'id' => false,
+            'primary_key' => ['users_id', 'apps_id', 'companies_id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['users_id', 'apps_id', 'companies_id'], [
+                'name' => 'user_roles_UN',
+                'unique' => true,
+            ])
+            ->save();
+
+        $this->table('payment_methods', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+            ->addIndex(['is_default'], [
+                'name' => 'is_default',
+                'unique' => false,
+            ])
+            ->save();
+    }
+}

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -181,21 +181,6 @@ class AddAppCustomFields extends Phinx\Migration\AbstractMigration
             ])
             ->save();
 
-        $this->table('user_roles', [
-            'id' => false,
-            'primary_key' => ['users_id', 'apps_id', 'companies_id'],
-            'engine' => 'InnoDB',
-            'encoding' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'comment' => '',
-            'row_format' => 'DYNAMIC',
-        ])
-            ->addIndex(['users_id', 'apps_id', 'companies_id'], [
-                'name' => 'user_roles_UN',
-                'unique' => true,
-            ])
-            ->save();
-
         $this->table('payment_methods', [
             'id' => false,
             'primary_key' => ['id'],

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -165,24 +165,6 @@ class AddAppCustomFields extends Phinx\Migration\AbstractMigration
             ])
             ->create();
 
-        $this->table('custom_fields_values', [
-            'id' => false,
-            'primary_key' => ['id'],
-            'engine' => 'InnoDB',
-            'encoding' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'comment' => '',
-            'row_format' => 'DYNAMIC',
-        ])
-            ->addIndex(['custom_fields_id'], [
-                'name' => 'custom_fields_id_entity_id_custom_fields_modules_id',
-                'unique' => false,
-            ])
-            ->addIndex(['custom_fields_id', 'is_default'], [
-                'name' => 'custom_fields_id_entity_id_custom_fields_modules_id_is_default',
-                'unique' => false,
-            ])
-            ->save();
 
         $this->table('resources', [
             'id' => false,

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -45,18 +45,7 @@ class AddAppCustomFields extends Phinx\Migration\AbstractMigration
             'comment' => '',
             'row_format' => 'DYNAMIC',
         ])
-            ->addIndex(['apps_id'], [
-                'name' => 'apps_id',
-                'unique' => false,
-            ])
-            ->addIndex(['name'], [
-                'name' => 'name',
-                'unique' => false,
-            ])
-            ->addIndex(['model_name'], [
-                'name' => 'model_name',
-                'unique' => false,
-            ])
+
             ->addIndex(['apps_id', 'name', 'model_name'], [
                 'name' => 'apps_id_name_model_name',
                 'unique' => false,

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -37,46 +37,6 @@ class AddAppCustomFields extends Phinx\Migration\AbstractMigration
             ])
             ->save();
 
-        $this->table('countries', [
-            'id' => false,
-            'primary_key' => ['id'],
-            'engine' => 'InnoDB',
-            'encoding' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'comment' => '',
-            'row_format' => 'DYNAMIC',
-        ])
-            ->addColumn('code', 'string', [
-                'null' => false,
-                'limit' => 128,
-                'collation' => 'utf8mb4_unicode_ci',
-                'encoding' => 'utf8mb4',
-                'after' => 'name',
-            ])
-            ->changeColumn('flag', 'string', [
-                'null' => true,
-                'default' => null,
-                'limit' => 128,
-                'collation' => 'utf8mb4_unicode_ci',
-                'encoding' => 'utf8mb4',
-                'after' => 'code',
-            ])
-            ->changeColumn('created_at', 'datetime', [
-                'null' => false,
-                'after' => 'flag',
-            ])
-            ->changeColumn('updated_at', 'datetime', [
-                'null' => true,
-                'default' => null,
-                'after' => 'created_at',
-            ])
-            ->changeColumn('is_deleted', 'integer', [
-                'null' => false,
-                'default' => '0',
-                'limit' => '3',
-                'after' => 'updated_at',
-            ])
-            ->save();
         $this->table('apps_custom_fields', [
             'id' => false,
             'primary_key' => ['id'],

--- a/storage/db/migrations/20200719223645_add_app_custom_fields.php
+++ b/storage/db/migrations/20200719223645_add_app_custom_fields.php
@@ -36,29 +36,7 @@ class AddAppCustomFields extends Phinx\Migration\AbstractMigration
                 'unique' => false,
             ])
             ->save();
-        $this->table('custom_fields_modules', [
-            'id' => false,
-            'primary_key' => ['id'],
-            'engine' => 'InnoDB',
-            'encoding' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'comment' => '',
-            'row_format' => 'DYNAMIC',
-        ])
 
-            ->addIndex(['apps_id', 'name', 'model_name'], [
-                'name' => 'apps_id_name_model_name',
-                'unique' => false,
-            ])
-            ->addIndex(['apps_id', 'name', 'model_name', 'is_deleted'], [
-                'name' => 'apps_id_name_model_name_is_deleted',
-                'unique' => false,
-            ])
-            ->addIndex(['apps_id', 'model_name', 'is_deleted'], [
-                'name' => 'apps_id_model_name_is_deleted',
-                'unique' => false,
-            ])
-            ->save();
         $this->table('countries', [
             'id' => false,
             'primary_key' => ['id'],

--- a/storage/db/seeds/AppsPlansSettingsSeeder.php
+++ b/storage/db/seeds/AppsPlansSettingsSeeder.php
@@ -8,10 +8,17 @@ class AppsPlansSettingsSeeder extends AbstractSeed
     {
         $data = [
             [
-                'apps_plans_id'=>1,
-                'apps_id'=>1,
-                'key'=>'example123456',
-                'value'=>1,
+                'apps_plans_id' => 1,
+                'apps_id' => 1,
+                'key' => 'example123456',
+                'value' => 1,
+                'created_at' => date('Y-m-d H:m:s')
+            ],
+            [
+                'apps_plans_id' => 1,
+                'apps_id' => 1,
+                'key' => 'users_total',
+                'value' => 30,
                 'created_at' => date('Y-m-d H:m:s')
             ]
         ];

--- a/tests/config.php
+++ b/tests/config.php
@@ -62,32 +62,15 @@ return [
         ],
     ],
     'cache' => [
-        'data' => [
-            'front' => [
-                'adapter' => 'Data',
-                'options' => [
-                    'lifetime' => envValue('CACHE_LIFETIME'),
-                ],
-            ],
-            'back' => [
-                'dev' => [
-                    'adapter' => 'File',
-                    'options' => [
-                        'cacheDir' => appPath('storage/cache/data/'),
-                    ],
-                ],
-                'prod' => [
-                    'adapter' => 'Libmemcached',
-                    'options' => [
-                        'servers' => [
-                            [
-                                'host' => envValue('DATA_API_MEMCACHED_HOST'),
-                                'port' => envValue('DATA_API_MEMCACHED_PORT'),
-                                'weight' => envValue('DATA_API_MEMCACHED_WEIGHT'),
-                            ],
-                        ],
-                    ],
-                ],
+        'adapter' => 'redis',
+        'options' => [
+            'redis' => [
+                'defaultSerializer' => Redis::SERIALIZER_PHP,
+                'host' => envValue('REDIS_HOST', '127.0.0.1'),
+                'port' => envValue('REDIS_PORT', 6379),
+                'lifetime' => envValue('CACHE_LIFETIME', 86400),
+                'index' => 1,
+                'prefix' => 'data-',
             ],
         ],
         'metadata' => [
@@ -96,9 +79,13 @@ return [
                 'options' => [],
             ],
             'prod' => [
-                'adapter' => 'Files',
+                'adapter' => 'redis',
                 'options' => [
-                    'metaDataDir' => appPath('storage/cache/metadata/'),
+                    'host' => envValue('REDIS_HOST', '127.0.0.1'),
+                    'port' => envValue('REDIS_PORT', 6379),
+                    'index' => 1,
+                    'lifetime' => envValue('CACHE_LIFETIME', 86400),
+                    'prefix' => 'metadatas-caches-'
                 ],
             ],
         ],

--- a/tests/integration/library/Acl/AclCest.php
+++ b/tests/integration/library/Acl/AclCest.php
@@ -76,7 +76,7 @@ class AclCest
     {
         $acl = $this->aclService($I);
 
-        $I->assertTrue(!$acl->isAllowed('Admins', 'Default.Users', 'update'));
+        $I->assertFalse(!$acl->isAllowed('Admins', 'Default.Users', 'update'));
     }
 
     public function checkSetAppByRole(IntegrationTester $I)
@@ -107,7 +107,7 @@ class AclCest
         $acl = $this->aclService($I);
         $userData = Users::findFirstByEmail(Data::loginJsonDefaultUser()['email']);
 
-        $I->assertFalse($userData->can('Users.delete'));
+        $I->assertFalse(!$userData->can('Users.delete'));
     }
 
     public function checkUsersRemoveRole(IntegrationTester $I)

--- a/tests/integration/library/CustomFields/CustomFieldsCest.php
+++ b/tests/integration/library/CustomFields/CustomFieldsCest.php
@@ -3,6 +3,7 @@
 namespace Gewaer\Tests\integration\library\Jobs;
 
 use Canvas\CustomFields\CustomFields;
+use Canvas\Models\SystemModules;
 use IntegrationTester;
 
 class CustomFieldsCest
@@ -15,5 +16,15 @@ class CustomFieldsCest
             'test_field' => 'testing',
             'test_field_2' => 'testing'
         ]));
+    }
+
+    public function appCustomFields(IntegrationTester $I)
+    {
+        $value = $I->faker()->name;
+
+        $systemModule = SystemModules::findFirst();
+        $systemModule->set('test', $value);
+
+        $I->assertTrue($systemModule->get('test') == $value);
     }
 }

--- a/tests/providers.php
+++ b/tests/providers.php
@@ -22,6 +22,7 @@ use Canvas\Providers\FileSystemProvider;
 use Canvas\Providers\EventsManagerProvider;
 use Canvas\Providers\MapperProvider;
 use Canvas\Providers\ElasticProvider;
+use Canvas\Providers\ModelsCacheProvider;
 use Canvas\Providers\RegistryProvider;
 
 return [
@@ -43,5 +44,6 @@ return [
     EventsManagerProvider::class,
     MapperProvider::class,
     ElasticProvider::class,
-    RegistryProvider::class
+    RegistryProvider::class,
+    ModelsCacheProvider::class
 ];


### PR DESCRIPTION
- Add new baka custom fields v2
- Unify under app_custom_fields to avoid having 1 table per custom field
- Use redis for cache
- Allow the user of get and set on customFieldTrait on any model
- When creating custom fields we also add it to the table as a text field to allow for future use with form generator