### PR TITLE
[WIP] Social Media Validation Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
         "sentry/sentry": "^2.4",
         "sly/notification-pusher": "2.x",
         "vlucas/phpdotenv": "^2.4",
-        "bakaphp/php-apple-signin": "^2.0"
+        "bakaphp/php-apple-signin": "^2.0",
+        "facebook/graph-sdk": "5.7.0",
+        "google/apiclient": "v2.7.0"
     },
     "require-dev": {
         "codeception/verify": "*",

--- a/src/Api/Controllers/AuthController.php
+++ b/src/Api/Controllers/AuthController.php
@@ -331,10 +331,9 @@ class AuthController extends \Baka\Auth\AuthController
             $appleUserInfo = $source->validateAppleUser($request['social_id']);
             $request['social_id'] = $appleUserInfo->sub;
             $request['email'] = $appleUserInfo->email;
-        } elseif (!$source->validation($request['email'], $request['social_id'])) {
-            throw new Exception('Invalid user');
+        } else {
+            $source->validation($request['email'], $request['social_id']);
         }
-
         return $this->response($this->providerLogin($source, $request['social_id'], $request));
     }
 

--- a/src/Api/Controllers/AuthController.php
+++ b/src/Api/Controllers/AuthController.php
@@ -331,6 +331,8 @@ class AuthController extends \Baka\Auth\AuthController
             $appleUserInfo = $source->validateAppleUser($request['social_id']);
             $request['social_id'] = $appleUserInfo->sub;
             $request['email'] = $appleUserInfo->email;
+        } elseif (!$source->validation($request['email'], $request['social_id'])) {
+            throw new Exception('Invalid user');
         }
 
         return $this->response($this->providerLogin($source, $request['social_id'], $request));

--- a/src/Models/Sources.php
+++ b/src/Models/Sources.php
@@ -138,7 +138,7 @@ class Sources extends AbstractModel
                 break;
             }
         } catch (Throwable $e) {
-            throw new Exception($e->getMessage());
+            throw $e;
         }
     }
 }

--- a/src/Models/Sources.php
+++ b/src/Models/Sources.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Canvas\Models;
 
-use Phalcon\Di;
-use Canvas\Exception\ModelException;
 use Baka\ASDecoder;
 use Canvas\Http\Exception\InternalServerErrorException;
-
+use Facebook\Facebook;
+use Google_Client;
+use Throwable;
 
 /**
- * Class Resources
+ * Class Resources.
  *
  * @package Canvas\Models
  *
@@ -21,7 +21,7 @@ class Sources extends AbstractModel
 {
     /**
      *
-     * @var integer
+     * @var int
      */
     public $id;
 
@@ -39,7 +39,7 @@ class Sources extends AbstractModel
 
     /**
      *
-     * @var integer
+     * @var int
      */
     public $language_id;
 
@@ -57,7 +57,7 @@ class Sources extends AbstractModel
 
     /**
      *
-     * @var integer
+     * @var int
      */
     public $is_deleted;
 
@@ -74,25 +74,27 @@ class Sources extends AbstractModel
      *
      * @return string
      */
-    public function getSource(): string
+    public function getSource() : string
     {
         return 'sources';
     }
 
     /**
-     * Verify if source is Apple
+     * Verify if source is Apple.
      */
-    public function isApple(): bool
+    public function isApple() : bool
     {
         return $this->title == 'apple';
     }
 
     /**
      * Validate Apple User.
+     *
      * @param string $identityToken
+     *
      * @return object
      */
-    public function validateAppleUser(string $identityToken): object
+    public function validateAppleUser(string $identityToken) : object
     {
         $appleUserInfo = ASDecoder::getAppleSignInPayload($identityToken);
 
@@ -101,5 +103,53 @@ class Sources extends AbstractModel
         }
 
         return $appleUserInfo;
+    }
+
+    /**
+     * validation.
+     *
+     * @param  string $email
+     * @param  string $token
+     *
+     * @return bool
+     */
+    public function validation(string $email, string $token) : bool
+    {
+        switch ($this->title) {
+            case 'google':
+                try {
+                    $client = new Google_Client([
+                        'client_id' => getenv('GOOGLE_CLIENT_ID')
+                    ]);
+                    $payload = $client->verifyIdToken($token);
+                    if ($payload) {
+                        $userid = $payload['sub'];
+                        return $payload['email'] === $email;
+                    } else {
+                        return false;
+                    }
+                } catch (Throwable $e) {
+                    return false;
+                }
+                break;
+            case 'facebook':
+                try {
+                    $fb = new Facebook([
+                        'app_id' => getenv('FACEBOOK_APP_ID'),
+                        'app_secret' => getenv('FACEBOOK_APP_SECRET'),
+                        'default_graph_version' => 'v8.0',
+                        // . . .
+                    ]);
+                    $response = $fb->get('/me', $token);
+                    $user = $response->getGraphUser();
+                    if ($user) {
+                        return true;
+                    }
+                    return false;
+                } catch (Exception $e) {
+                    return false;
+                }
+            break;
+        }
     }
 }

--- a/src/Models/Sources.php
+++ b/src/Models/Sources.php
@@ -7,7 +7,6 @@ namespace Canvas\Models;
 use Baka\ASDecoder;
 use Canvas\Http\Exception\InternalServerErrorException;
 use Exception;
-use Throwable;
 
 /**
  * Class Resources.
@@ -115,8 +114,7 @@ class Sources extends AbstractModel
     public function validation(string $email, string $token) : bool
     {
         $di = DI::getDefault();
-        try {
-            switch ($this->title) {
+        switch ($this->title) {
                 case 'google':
                         $client = $di->getGoogle();
                         $payload = $client->verifyIdToken($token);
@@ -136,9 +134,6 @@ class Sources extends AbstractModel
                         }
                         throw new Exception('Invalid user on facebook validation');
                 break;
-            }
-        } catch (Throwable $e) {
-            throw $e;
         }
     }
 }

--- a/src/Providers/SocialProvider.php
+++ b/src/Providers/SocialProvider.php
@@ -16,16 +16,14 @@ class SocialProvider implements ServiceProviderInterface
      */
     public function register(DiInterface $container)
     {
-        $app = envValue('GEWAER_APP_ID', 1);
-
         $container->setShared(
             'facebook',
             function (bool $prefix = true) use ($app) {
                 //Connect to redis
 
                 $fb = new Facebook([
-                    'app_id' => getenv('FACEBOOK_APP_ID'),
-                    'app_secret' => getenv('FACEBOOK_APP_SECRET'),
+                    'app_id' => envValue('FACEBOOK_APP_ID'),
+                    'app_secret' => envValue('FACEBOOK_APP_SECRET'),
                     'default_graph_version' => 'v8.0',
                     // . . .
                 ]);
@@ -38,7 +36,7 @@ class SocialProvider implements ServiceProviderInterface
             function (bool $prefix = true) use ($app) {
                 //Connect to redis
                 $client = new Google_Client([
-                    'client_id' => getenv('GOOGLE_CLIENT_ID')
+                    'client_id' => envValue('GOOGLE_CLIENT_ID')
                 ]);
                 return $client;
             }

--- a/src/Providers/SocialProvider.php
+++ b/src/Providers/SocialProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Canvas\Providers;
+
+use function Canvas\Core\envValue;
+use Facebook\Facebook;
+use Google_Client;
+use Phalcon\Di\ServiceProviderInterface;
+use Phalcon\DiInterface;
+use Redis;
+
+class SocialProvider implements ServiceProviderInterface
+{
+    /**
+     * @param DiInterface $container
+     */
+    public function register(DiInterface $container)
+    {
+        $app = envValue('GEWAER_APP_ID', 1);
+
+        $container->setShared(
+            'facebook',
+            function (bool $prefix = true) use ($app) {
+                //Connect to redis
+
+                $fb = new Facebook([
+                    'app_id' => getenv('FACEBOOK_APP_ID'),
+                    'app_secret' => getenv('FACEBOOK_APP_SECRET'),
+                    'default_graph_version' => 'v8.0',
+                    // . . .
+                ]);
+                return $fb;
+            }
+        );
+
+        $container->setShared(
+            'google',
+            function (bool $prefix = true) use ($app) {
+                //Connect to redis
+                $client = new Google_Client([
+                    'client_id' => getenv('GOOGLE_CLIENT_ID')
+                ]);
+                return $client;
+            }
+        );
+    }
+}


### PR DESCRIPTION
Validation of access token for facebook and google.  On both case i use try catch , on the future i want use sentry for log on cath.
In facebook validation i dont have a way for validate email of user, because my example facebook app, is on development mode, and facebook require production mode for give me  user email.

My sugestion for the next step after this PR:

- Better Facebook Validation
- Add sentry on catch  statement
- Add Instagram Validation