### PR TITLE
[0.2] Remove Kanvas Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "php": ">=7.4",
         "ext-phalcon": ">=4",
         "baka/baka": "0.6.x-dev",
-        "kanvas/packages": "0.1.x-dev",
         "dariuszp/cli-progress-bar": "^1.0",
         "elasticsearch/elasticsearch": "^7.5",
         "firebase/php-jwt": "^5.0",


### PR DESCRIPTION
After reviewing this change some more, we won't need to add kanvas package to the core, for these specific scenarios we will need the dev to implement the trait on the payment controller and overwrite the routes.

Since we know this is not a default behavior, only for mobile apps, this is an acceptable scenario.

Dont accept since we need to move the code to the kanvas package trait to make is simpler to implement on the proyects