### PR TITLE
[0.2] Decode the request URI before the application handle

### DIFF
--- a/src/Bootstrap/Api.php
+++ b/src/Bootstrap/Api.php
@@ -6,9 +6,9 @@ namespace Canvas\Bootstrap;
 
 use function Baka\appPath;
 use Baka\Http\Request\Phalcon as Request;
+use Canvas\Http\Response;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Mvc\Micro;
-use Canvas\Http\Response;
 use Throwable;
 
 /**
@@ -29,7 +29,8 @@ class Api extends AbstractBootstrap
     {
         try {
             $request = new Request();
-            return $this->application->handle($request->getServer('REQUEST_URI'));
+            $uri = rawurldecode($request->getServer('REQUEST_URI'));
+            return $this->application->handle($uri);
         } catch (Throwable $e) {
             $response = new Response();
             $response->handleException($e)->send();
@@ -46,8 +47,8 @@ class Api extends AbstractBootstrap
         //set all the services
 
         /**
-        * @todo Find a better way to handle unit test file include
-        */
+         * @todo Find a better way to handle unit test file include
+         */
         $this->providers = require appPath('api/config/providers.php');
 
         //run my parents setup


### PR DESCRIPTION
## Overview
For requests that are URL Encoded we need to decode the URI before handling it. With this we make sure that all the parameters the controllers get are decoded. This adds backward compatibility with Kanvas 0.1.
### Example
For the following request it would decode the games Ids as shown:
```POST /add-game/29%7C31%7C```

> `    Route::post('/add-game/{gameIds}')->controller('Configurator\\GamesController')->action('addGamesToSession'),`
> **gameIds = 29|31|**