### PR TITLE
[0.2] Refactor the Companies relationship to use CompaniesSettings instead of Baka CompanySettings

### DIFF
--- a/src/Models/Companies.php
+++ b/src/Models/Companies.php
@@ -49,7 +49,12 @@ class Companies extends AbstractModel
         $this->keepSnapshots(true);
         $this->addBehavior(new Blameable());
 
-        $this->hasMany('id', 'Baka\Auth\Models\CompanySettings', 'id', ['alias' => 'settings']);
+        $this->hasMany(
+            'id',
+            CompaniesSettings::class,
+            'companies_id',
+            ['alias' => 'settings']
+        );
 
         $this->belongsTo(
             'users_id',
@@ -347,8 +352,8 @@ class Companies extends AbstractModel
 
         //Lets create a new default subscription without payment method
         $this->user->newSubscription($defaultPlan->name, $defaultPlan->stripe_id, $this, $this->di->getApp())
-                ->trialDays($defaultPlan->free_trial_dates)
-                ->create();
+            ->trialDays($defaultPlan->free_trial_dates)
+            ->create();
 
         //ook for the subscription and update the missing info
         $subscription = $this->subscription;

--- a/tests/integration/library/Models/CompaniesCest.php
+++ b/tests/integration/library/Models/CompaniesCest.php
@@ -28,7 +28,7 @@ class CompaniesCest
 
         $expected = [
             [0, 'users_id', Users::class, 'id', ['alias' => 'user']],
-            [2, 'id', CompaniesSettings::class, 'id', ['alias' => 'settings']],
+            [2, 'id', CompaniesSettings::class, 'companies_id', ['alias' => 'settings']],
             [2, 'id', CompaniesBranches::class, 'companies_id', ['alias' => 'branches']],
             [2, 'id', CompaniesCustomFields::class, 'companies_id', ['alias' => 'fields']],
             [2, 'id', CustomFields::class, 'companies_id', ['alias' => 'custom-fields']],

--- a/tests/integration/library/Models/CompaniesCest.php
+++ b/tests/integration/library/Models/CompaniesCest.php
@@ -2,24 +2,22 @@
 
 namespace Gewaer\Tests\integration\library\Models;
 
-use Baka\Auth\Models\CompanySettings;
-use Canvas\Models\UserCompanyApps;
 use Canvas\CustomFields\CustomFields;
-use Canvas\Models\Companies;
 use Canvas\Models\Apps;
-use Canvas\Models\CompaniesGroups;
+use Canvas\Models\Companies;
 use Canvas\Models\CompaniesAssociations;
 use Canvas\Models\CompaniesBranches;
 use Canvas\Models\CompaniesCustomFields;
+use Canvas\Models\CompaniesGroups;
+use Canvas\Models\CompaniesSettings;
 use Canvas\Models\FileSystemEntities;
 use Canvas\Models\Subscription;
+use Canvas\Models\UserCompanyApps;
 use Canvas\Models\Users;
 use Canvas\Models\UsersAssociatedApps;
 use Canvas\Models\UsersAssociatedCompanies;
 use Canvas\Models\UserWebhooks;
 use IntegrationTester;
-use Canvas\Providers\ConfigProvider;
-use Phalcon\Di\FactoryDefault;
 use Phalcon\Security\Random;
 
 class CompaniesCest
@@ -30,7 +28,7 @@ class CompaniesCest
 
         $expected = [
             [0, 'users_id', Users::class, 'id', ['alias' => 'user']],
-            [2, 'id', CompanySettings::class, 'id', ['alias' => 'settings']],
+            [2, 'id', CompaniesSettings::class, 'id', ['alias' => 'settings']],
             [2, 'id', CompaniesBranches::class, 'companies_id', ['alias' => 'branches']],
             [2, 'id', CompaniesCustomFields::class, 'companies_id', ['alias' => 'fields']],
             [2, 'id', CustomFields::class, 'companies_id', ['alias' => 'custom-fields']],
@@ -38,7 +36,7 @@ class CompaniesCest
             [2, 'id', UsersAssociatedApps::class, 'companies_id', ['alias' => 'UsersAssociatedApps']],
             [2, 'id', UsersAssociatedApps::class, 'companies_id', ['alias' => 'UsersAssociatedByApps', 'params' => ['conditions' => 'apps_id = 1']]],
             [2, 'id', CompaniesAssociations::class, 'companies_id', ['alias' => 'companiesAssoc']],
-            [2, 'id', Subscription::class, 'companies_id', ['alias' => 'subscriptions', 'params'=> ['conditions' => 'apps_id = 1 AND is_deleted = 0', 'order' => 'id DESC']]],
+            [2, 'id', Subscription::class, 'companies_id', ['alias' => 'subscriptions', 'params' => ['conditions' => 'apps_id = 1 AND is_deleted = 0', 'order' => 'id DESC']]],
             [2, 'id', UserWebhooks::class, 'companies_id', ['alias' => 'user-webhooks']],
             [1, 'id', CompaniesBranches::class, 'companies_id', ['alias' => 'defaultBranch', 'params' => ['conditions' => 'is_default = 1']]],
             [1, 'id', CompaniesBranches::class, 'companies_id', ['alias' => 'branch']],
@@ -52,20 +50,19 @@ class CompaniesCest
         $I->assertEquals($expected, $actual);
     }
 
-
-
     /**
      * Get the Companies Group to which a newly created company belongs to.
      *
      * @param IntegrationTester $I
+     *
      * @return void
      */
     public function getCompaniesGroupsTest(IntegrationTester $I)
     {
         $app = Apps::getACLApp(Apps::CANVAS_DEFAULT_APP_NAME);
         $companyGroup = CompaniesGroups::findFirst([
-            'conditions'=>'users_id = ?0 and apps_id = ?1 and is_deleted = 0',
-            'bind'=>[$I->grabFromDi('userData')->id,$app->id]
+            'conditions' => 'users_id = ?0 and apps_id = ?1 and is_deleted = 0',
+            'bind' => [$I->grabFromDi('userData')->id, $app->id]
         ]);
         $I->assertTrue($companyGroup instanceof CompaniesGroups);
     }
@@ -74,14 +71,15 @@ class CompaniesCest
      * Register a new Company.
      *
      * @param IntegrationTester $I
+     *
      * @return void
      */
     public function getCompaniesAssociationsTest(IntegrationTester $I)
     {
         $company = Companies::getDefaultByUser($I->grabFromDi('userData'));
         $companyAssociations = CompaniesAssociations::findFirst([
-            'conditions'=>'companies_id = ?0 and is_deleted = 0',
-            'bind'=>[$company->id]
+            'conditions' => 'companies_id = ?0 and is_deleted = 0',
+            'bind' => [$company->id]
         ]);
         $I->assertTrue($companyAssociations instanceof CompaniesAssociations);
     }
@@ -90,6 +88,7 @@ class CompaniesCest
      * Register a new Company.
      *
      * @param IntegrationTester $I
+     *
      * @return void
      */
     public function getDefaultByUserTest(IntegrationTester $I)
@@ -102,6 +101,7 @@ class CompaniesCest
      * Get Associated Users by App.
      *
      * @param IntegrationTester $I
+     *
      * @return void
      */
     public function getAssociatedUsersByAppTest(IntegrationTester $I)
@@ -118,6 +118,7 @@ class CompaniesCest
      * Get Logo.
      *
      * @param IntegrationTester $I
+     *
      * @return void
      */
     public function getLogoTest(IntegrationTester $I)


### PR DESCRIPTION
### Overview
The relationship to get the settings of a company doesn't work because we are using the `CompanySettings` model from Baka, which have a different table name for the database than the one on Kanvas.
## Solution
- Update the `settings` relationship on the `Canvas\Models\Companies` model to use `Canvas\Models\CompaniesSettings`
- Update the `ComapniesCest` to validate the new relationship