### PR TITLE
[0.3] Create before SoftDelete function and job to use Cascade SoftDelete

### DIFF
--- a/src/Api/Controllers/FilesystemController.php
+++ b/src/Api/Controllers/FilesystemController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Canvas\Api\Controllers;
 
-use Canvas\Models\FileSystem;
 use Canvas\Contracts\FileManagementTrait;
+use Canvas\Models\FileSystem;
 
 class FilesystemController extends BaseController
 {

--- a/src/Cli/Jobs/CascadeSoftDelete.php
+++ b/src/Cli/Jobs/CascadeSoftDelete.php
@@ -34,7 +34,6 @@ class CascadeSoftDelete extends Job implements QueueableJobInterface
             $log->info('Cascade Soft Delete ' . get_class($this->model) . ' Id: ' . $this->model->getId());
 
             $this->model->cascadeSoftDelete();
-
         } catch (Throwable $e) {
             $log->error($e->getTraceAsString());
         }

--- a/src/Cli/Jobs/CascadeSoftDelete.php
+++ b/src/Cli/Jobs/CascadeSoftDelete.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Canvas\Cli\Jobs;
+
+use Baka\Contracts\Queue\QueueableJobInterface;
+use Baka\Jobs\Job;
+use Phalcon\Di;
+use Phalcon\Mvc\ModelInterface;
+use Throwable;
+
+class CascadeSoftDelete extends Job implements QueueableJobInterface
+{
+    protected ModelInterface $model;
+
+    /**
+     * Constructor.
+     *
+     * @param ModelInterface $model
+     */
+    public function __construct(ModelInterface $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Handle the cascade soft delete.
+     *
+     * @return bool
+     */
+    public function handle() : bool
+    {
+        $log = Di::getDefault()->get('log');
+        try {
+            $log->info('Cascade Soft Delete ' . get_class($this->model) . ' Id: ' . $this->model->getId());
+
+            $this->model->cascadeSoftDelete();
+
+        } catch (Throwable $e) {
+            $log->error($e->getTraceAsString());
+        }
+
+        return true;
+    }
+}

--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -28,13 +28,13 @@ abstract class AbstractModel extends BakaModel
     }
 
     /**
-     * Execute an before softDelete
+     * Execute an before softDelete.
      *
      * @return void
      */
     public function beforeSoftDelete() : void
     {
-        if($this->cascadeSoftDelete){
+        if ($this->cascadeSoftDelete) {
             CascadeSoftDelete::dispatch($this);
         }
     }

--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Canvas\Models;
 
 use Baka\Database\Model as BakaModel;
+use Canvas\Cli\Jobs\CascadeSoftDelete;
 
 abstract class AbstractModel extends BakaModel
 {
@@ -14,6 +15,7 @@ abstract class AbstractModel extends BakaModel
      * @var string
      */
     protected $subscriptionPlanLimitKey = null;
+    public bool $cascadeSoftDelete = true;
 
     /**
      * Get the primary id of this model.
@@ -23,5 +25,17 @@ abstract class AbstractModel extends BakaModel
     public function getId() : int
     {
         return (int) $this->id;
+    }
+
+    /**
+     * Execute an before softDelete
+     *
+     * @return void
+     */
+    public function beforeSoftDelete() : void
+    {
+        if($this->cascadeSoftDelete){
+            CascadeSoftDelete::dispatch($this);
+        }
     }
 }

--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -15,7 +15,7 @@ abstract class AbstractModel extends BakaModel
      * @var string
      */
     protected $subscriptionPlanLimitKey = null;
-    public bool $cascadeSoftDelete = true;
+    public bool $cascadeSoftDelete = false;
 
     /**
      * Get the primary id of this model.


### PR DESCRIPTION
### Overview
In order to soft delete data using cascade method, we need to send that data to a job that call a softdelete function for the relationships of the entity.

### Solution
Create a boolean property on abstract model called cascade softDelete to let kwon the function that softDelete is a cascade one.
Create a Job called cascade softDelete that execute the method softDelete for all the hasOne, hasMany relation of the entity.