### PR TITLE
[0.3] Fix mail suscription validation on mailNotification

### DIFF
--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -367,7 +367,7 @@ class Notification implements NotificationInterface
     public function toMailNotification() : bool
     {
         $toMail = $this->toMail();
-        if ($toMail instanceof Message) {
+        if ($toMail instanceof Message && !$this->toUser->isUnsubscribe($this->type->getId())) {
             $this->fire('notification:sendMail', $toMail);
         }
 


### PR DESCRIPTION
### Overview
When sending a mail notification, i dont need to recieve the mail if im unsuscribed of that type of notification.

### Resolve
Validate if the user is suscribe to that notification type before sending it.