### PR TITLE
[0.2] Create notification type if not found

### DIFF
--- a/src/Models/NotificationType.php
+++ b/src/Models/NotificationType.php
@@ -54,7 +54,7 @@ class NotificationType extends AbstractModel
      * @param Model $model
      * @return NotificationType
      */
-    public static function getByKeyOrCreate(string $key, Model $model = null) : NotificationType
+    public static function getByKeyOrCreate(string $key, ?Model $model = null) : NotificationType
     {
         $app = Di::getDefault()->getApp();
         $systemModule = SystemModules::getByModelName(get_class($model));

--- a/src/Models/NotificationType.php
+++ b/src/Models/NotificationType.php
@@ -71,6 +71,7 @@ class NotificationType extends AbstractModel
                 'system_modules_id' => $systemModule->getId(),
                 'name' => get_class($model),
                 'key' => $key,
+                'with_realtime' => 0
             ]
         );
     }

--- a/src/Models/NotificationType.php
+++ b/src/Models/NotificationType.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Canvas\Models;
 
+use Baka\Database\Model;
+use Baka\Database\SystemModules;
 use Phalcon\Di;
 
 class NotificationType extends AbstractModel
@@ -44,5 +46,33 @@ class NotificationType extends AbstractModel
                 $key
             ]
         ]);
+    }
+
+    /**
+     * Get notification by its key or create it.
+     *
+     * @param string $key
+     * @param Model $model
+     * @return NotificationType
+     */
+    public static function getByKeyOrCreate(string $key, Model $model = null) : NotificationType
+    {
+        $app = Di::getDefault()->getApp();
+        $systemModule = SystemModules::getSystemModuleByModelName(get_class($model));
+        
+        return self::findFirstOrCreate([
+            'conditions' => 'apps_id in (?0, ?1) AND key = ?2',
+            'bind' => [
+                $app->getId(),
+                Apps::CANVAS_DEFAULT_APP_ID,
+                $key
+            ]
+            ],[
+                'apps_id' => $app->getId(),
+                'system_modules_id' => $systemModule->getId(),
+                'name' => get_class($model),
+                'key' => $key,
+            ]
+        );
     }
 }

--- a/src/Models/NotificationType.php
+++ b/src/Models/NotificationType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Canvas\Models;
 
 use Baka\Database\Model;
-use Baka\Database\SystemModules;
 use Phalcon\Di;
 
 class NotificationType extends AbstractModel
@@ -58,7 +57,7 @@ class NotificationType extends AbstractModel
     public static function getByKeyOrCreate(string $key, Model $model = null) : NotificationType
     {
         $app = Di::getDefault()->getApp();
-        $systemModule = SystemModules::getSystemModuleByModelName(get_class($model));
+        $systemModule = SystemModules::getByModelName(get_class($model));
         
         return self::findFirstOrCreate([
             'conditions' => 'apps_id in (?0, ?1) AND key = ?2',

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -254,7 +254,7 @@ class Notification implements NotificationInterface
     {
         //if the user didn't provide the type get it based on the class name
         if (is_null($this->type)) {
-            $this->setType(NotificationType::getByKey(static::class));
+            $this->setType(NotificationType::getByKeyOrCreate(static::class, $this->entity));
         } elseif (is_string($this->type)) {
             //not great but for now lets use it
             $this->setType(NotificationType::getByKey($this->type));

--- a/storage/db/seeds/InitGewaer.php
+++ b/storage/db/seeds/InitGewaer.php
@@ -420,6 +420,23 @@ class InitGewaer extends AbstractSeed
                 'mobile_component_type' => null,
                 'mobile_navigation_type' => null,
                 'mobile_tab_index' => '0'
+            ],
+            [
+                'name' => 'Users Invite',
+                'slug' => 'users-invite',
+                'model_name' => 'Canvas\\Models\\UsersInvite',
+                'apps_id' => '1',
+                'parents_id' => '0',
+                'menu_order' => null,
+                'show' => '0',
+                'use_elastic' => '0',
+                'browse_fields' => '[{"name":"email","title":"Email","sortField":"email","filterable":true,"searchable":true},{"name":"roles.0.name","title":"Roles","sortField":"roles_id","filterable":true}]',
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => null,
+                'is_deleted' => '0',
+                'mobile_component_type' => null,
+                'mobile_navigation_type' => null,
+                'mobile_tab_index' => '0'
             ]
         ];
 

--- a/tests/integration/library/Models/NotificationTypeCest.php
+++ b/tests/integration/library/Models/NotificationTypeCest.php
@@ -3,6 +3,7 @@
 namespace Gewaer\Tests\integration\library\Models;
 
 use Canvas\Models\NotificationType;
+use Canvas\Models\Users;
 use IntegrationTester;
 
 class NotificationTypeCest
@@ -17,6 +18,20 @@ class NotificationTypeCest
     public function getByKey(IntegrationTester $I)
     {
         $notificationType = NotificationType::getByKey('Canvas\Notifications\Users');
+        $I->assertTrue($notificationType instanceof NotificationType);
+    }
+
+    /**
+     * Get the notification by its key or created it
+     *
+     * @param IntegrationTester $I
+     * @return void
+     */
+    public function getByKeyOrCreate(IntegrationTester $I)
+    {
+        $model = new Users();
+
+        $notificationType = NotificationType::getByKeyOrCreate('User-Key', $model);
         $I->assertTrue($notificationType instanceof NotificationType);
     }
 }


### PR DESCRIPTION
### Version: 0.2

### Description:
Create a method getByKeyOrCreate on notificationTypes, because sometimes we need to create on the way the notification type without a extra request for thoes who doesnt have an admin panel


### Features: 
getByKeyOrCreate : We need a method to create a notification type on the fly. 

