### PR TITLE
[0.3] fix: check if resultset is empty

### DIFF
--- a/src/Contracts/FileSystemModelTrait.php
+++ b/src/Contracts/FileSystemModelTrait.php
@@ -543,7 +543,8 @@ trait FileSystemModelTrait
         ';
 
         $key = self::generateCacheKey($bindParams);
-        if (!$resultSet = $redis->get($key)) {
+        $resultSet = $redis->get($key);
+        if (!$resultSet || !$resultSet->count()) {
             $fileSystemEntities = new FileSystemEntities();
             // Execute the query
             $resultSet = new Resultset(


### PR DESCRIPTION
Version: 0.3
Description:
Check if the resultset storage in redis has rows

Bug: When i do a find in phalcon , phalcon returned a Simple Resultset object, this objects can has rows or no, but always is a Simple Resultset, when i use this object in the if sentences, always is true, because object is a valid value 
