### PR TITLE
[0.3] Change invite process when inviting User is deleted

### DIFF
--- a/src/Models/Companies.php
+++ b/src/Models/Companies.php
@@ -302,7 +302,7 @@ class Companies extends AbstractModel
      */
     public function userAssociatedToCompany(Users $user) : bool
     {
-        return $this->countUsersAssociatedApps('users_id =' . $user->getId() . ' and apps_id = ' . Di::getDefault()->get('app')->getId()) > 0;
+        return $this->countUsersAssociatedApps('users_id =' . $user->getId() . ' and apps_id = ' . Di::getDefault()->get('app')->getId() . ' and is_deleted = 0') > 0;
     }
 
     /**

--- a/src/Models/UsersInvite.php
+++ b/src/Models/UsersInvite.php
@@ -103,7 +103,11 @@ class UsersInvite extends AbstractModel
         ]);
 
         if (is_object($userExists)) {
-            if ($userData->defaultCompany->userAssociatedToCompany($userExists)) {
+            $softDeleteCheck = UsersAssociatedApps::findFirst([
+                'conditions' => 'users_id = ?0 and companies_id = ?1 and is_deleted = 0',
+                'bind' => [$userExists->id, $userData->currentCompanyId()]
+            ]);
+            if ($userData->defaultCompany->userAssociatedToCompany($userExists) && !empty($softDeleteCheck)) {
                 throw new ModelNotFoundException('User already is associated with this company app');
             }
         }


### PR DESCRIPTION
Version: 0.3

Description:

Changes in the invite process when inviting user that was deleted before.

Features: when an erased user is invited to the system the following error messages appear `This user is already associated with this app` or `User already has an account ` when processing the invitation.

Bug: when an user is deleted the relationship with the app is softdeleted, the invite process will not recognized the softdeleted relationship as deleted for that reason when the invitation is made it will throw the previously stated errors.
