### PR TITLE
add users forgot code

### DIFF
--- a/src/Models/Users.php
+++ b/src/Models/Users.php
@@ -61,6 +61,7 @@ class Users extends AbstractModel implements UserInterface
     public ?int $city_id = 0;
     public ?int $state_id = 0;
     public ?int $country_id = 0;
+    public ?int $user_recover_code = 0;
     public int $welcome = 0;
     public int $user_active = 0;
     public ?string $user_activation_key = null;
@@ -800,6 +801,19 @@ class Users extends AbstractModel implements UserInterface
         $this->updateOrFail();
 
         return $this->user_activation_forgot;
+    }
+
+    /**
+     * Generate new forgot password code.
+     *
+     * @return string
+     */
+    public function generateForgotCode() : string
+    {
+        $this->user_recover_code = sprintf("%06d", mt_rand(1, 999999));
+        $this->updateOrFail();
+
+        return $this->user_recover_code;
     }
 
     /**

--- a/src/Models/Users.php
+++ b/src/Models/Users.php
@@ -810,7 +810,8 @@ class Users extends AbstractModel implements UserInterface
      */
     public function generateForgotCode() : string
     {
-        $this->user_recover_code = sprintf("%06d", mt_rand(1, 999999));
+        $random = new Random();
+        $this->user_recover_code = sprintf("%06d", $random->number(999999));
         $this->updateOrFail();
 
         return $this->user_recover_code;

--- a/storage/db/migrations/20210604193743_users_forgot_code.php
+++ b/storage/db/migrations/20210604193743_users_forgot_code.php
@@ -11,7 +11,7 @@ class UsersForgotCode extends Phinx\Migration\AbstractMigration
             'primary_key' => ['id'],
             'engine' => 'InnoDB',
             'encoding' => 'utf8',
-            'collation' => 'latin1_swedish_ci',
+            'collation' => 'utf8mb4_unicode_ci',
             'comment' => '',
             'row_format' => 'DYNAMIC',
         ])

--- a/storage/db/migrations/20210604193743_users_forgot_code.php
+++ b/storage/db/migrations/20210604193743_users_forgot_code.php
@@ -1,0 +1,26 @@
+<?php
+
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class UsersForgotCode extends Phinx\Migration\AbstractMigration
+{
+    public function change()
+    {
+        $this->table('users', [
+            'id' => false,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'encoding' => 'utf8',
+            'collation' => 'latin1_swedish_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ])
+        ->addColumn('user_recover_code', 'integer', [
+            'null' => true,
+            'default' => null,
+            'limit' => MysqlAdapter::INT_REGULAR,
+            'after' => 'zip_code',
+        ])
+        ->save();
+    }
+}


### PR DESCRIPTION
Version: 0.3

Description:

add user_recover_code field to user table to handle password recovery codes.

Features: Looking for an easier way to change the password from a mobile application 
