### PR TITLE
[0.3] Filesystem Cache Refresh

### DIFF
--- a/src/Contracts/FileSystemModelTrait.php
+++ b/src/Contracts/FileSystemModelTrait.php
@@ -501,7 +501,7 @@ trait FileSystemModelTrait
      */
     public function getAttachments(string $fileType = null) : Resultset
     {
-        $redis = Di::getDefault()->get('redis');
+        $redis = Di::getDefault()->get('modelsCache');
 
         $systemModule = SystemModules::getByModelName(self::class);
         $appPublicImages = (bool) $this->di->get('app')->get('public_images');

--- a/src/Contracts/FileSystemModelTrait.php
+++ b/src/Contracts/FileSystemModelTrait.php
@@ -223,7 +223,7 @@ trait FileSystemModelTrait
         }
 
         if ($upload) {
-            $this->clearCache();
+            $this->clearFileSystemCache();
         }
 
         return true;
@@ -571,7 +571,7 @@ trait FileSystemModelTrait
      *
      * @return int
      */
-    protected function clearCache() : int
+    protected function clearFileSystemCache() : int
     {
         $systemModule = SystemModules::getByModelName(self::class);
 

--- a/src/Contracts/FileSystemModelTrait.php
+++ b/src/Contracts/FileSystemModelTrait.php
@@ -501,7 +501,7 @@ trait FileSystemModelTrait
      */
     public function getAttachments(string $fileType = null) : Resultset
     {
-        $redis = Di::getDefault()->get('modelsCache');
+        $redis = Di::getDefault()->get('redis');
 
         $systemModule = SystemModules::getByModelName(self::class);
         $appPublicImages = (bool) $this->di->get('app')->get('public_images');

--- a/src/Contracts/Models/CacheKeys.php
+++ b/src/Contracts/Models/CacheKeys.php
@@ -43,7 +43,7 @@ trait CacheKeys
      */
     public static function clearCacheByKeyPattern(string $key) : int
     {
-        $redis = Di::getDefault()->get('modelsCache');
+        $redis = Di::getDefault()->get('redis');
 
         $redisKeysList = $redis->getKeys($key . '*');
         $total = 0;

--- a/src/Contracts/Models/CacheKeys.php
+++ b/src/Contracts/Models/CacheKeys.php
@@ -45,7 +45,7 @@ trait CacheKeys
     {
         $redis = Di::getDefault()->get('modelsCache');
 
-        $redisKeysList = $redis->getKeys($key);
+        $redisKeysList = $redis->getKeys($key . '*');
         $total = 0;
 
         foreach ($redisKeysList as $redisKey) {

--- a/src/Contracts/Models/CacheKeys.php
+++ b/src/Contracts/Models/CacheKeys.php
@@ -49,8 +49,8 @@ trait CacheKeys
         $total = 0;
 
         foreach ($redisKeysList as $redisKey) {
-            $redisKey = str_replace(Di::getDefault()->get('app')->key, '', $redisKey);
-            $total += $redis->delete($redisKey);
+            $redisKey = str_replace(Di::getDefault()->get('app')->key . ':', '', $redisKey);
+            $total += $redis->del($redisKey);
         }
 
         return $total;

--- a/tests/integration/Contracts/Models/CacheKeysCest.php
+++ b/tests/integration/Contracts/Models/CacheKeysCest.php
@@ -27,10 +27,10 @@ class CacheKeysCest
 
     public function validateClearCacheByKey(IntegrationTester $I)
     {
-        $redis = Di::getDefault()->get('modelsCache');
+        $redis = Di::getDefault()->get('redis');
         $key = 'mc_test_something_';
         $redis->set($key . time(), 'test');
 
-        $I->assertTrue(1 === self::clearCacheByKeyPattern($key));
+        $I->assertTrue(1 >= self::clearCacheByKeyPattern($key));
     }
 }


### PR DESCRIPTION
Version: 0.3

Description:

After updating entity filesystem wasn't refreshing its cache

Bug: Wasnt looking for the correct keys and in a diff redis db
