### PR TITLE
Flush the sentry client when after logging errors on the queues

### DIFF
--- a/src/Cli/Tasks/QueueTask.php
+++ b/src/Cli/Tasks/QueueTask.php
@@ -115,9 +115,9 @@ class QueueTask extends PhTask
     {
         $queue = is_null($queueName) ? QUEUE::JOBS : $queueName;
 
-        $callback = function (object $msg) : void {
-            $sentryClient = SentrySdk::getCurrentHub()->getClient();
+        $sentryClient = SentrySdk::getCurrentHub()->getClient();
 
+        $callback = function (object $msg) use ($sentryClient) : void {
             try {
                 //check the db before running anything
                 $this->reconnectDb();


### PR DESCRIPTION
Version: 0.3.

Description:

Because of the way the queues work the Sentry client wasn't sending the errors to Sentry. To fix that we're flushing the captured errors every time a job fails on the queues.

Bug: We weren't sending the error logs to sentry on the queue jobs.

https://mctekk.atlassian.net/browse/SAW-1931