### PR TITLE
timestamp order hotfix

### DIFF
--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -505,6 +505,8 @@ class Notification implements NotificationInterface
         return true;
     }
 
+
+
     /**
      * Groups a set of notifications.
      *
@@ -544,7 +546,7 @@ class Notification implements NotificationInterface
         $sql = "SELECT * FROM notifications
                     WHERE notification_type_id = {$this->type->getId()}
                     AND entity_id = {$this->entity->getId()}
-                    AND TIMESTAMPDIFF(MINUTE, CURDATE(), updated_at) between {$this->softCap} and {$this->hardCap}
+                    AND TIMESTAMPDIFF(MINUTE, updated_at, NOW()) between {$this->softCap} and {$this->hardCap}
                     order by updated_at DESC limit 1";
 
         $notification = Notifications::findByRawSql($sql);

--- a/tests/_support/Notifications/NewFollower.php
+++ b/tests/_support/Notifications/NewFollower.php
@@ -26,8 +26,8 @@ class NewFollower extends Notification implements NotificationInterface
         
         if ($groupable) {
             $this->setGroupable(true);
-            $this->setSoftCap(1);
-            $this->setHardCap(2000);
+            $this->setSoftCap(0);
+            $this->setHardCap(10);
         }
     }
 


### PR DESCRIPTION
Version: 0.3

Description:

query was not calculating time diff correctly

Bug: replaced the MySQL function `CURDATE()` with `NOW()` since now comes with the minutes also swapped the order of the parameters since that was provoking negative results

