### PR TITLE
[0.3] fix: allow all queues to send info to sentry

### DIFF
--- a/src/Cli/Tasks/QueueTask.php
+++ b/src/Cli/Tasks/QueueTask.php
@@ -30,24 +30,37 @@ class QueueTask extends PhTask
      */
     public function eventsAction()
     {
-        $callback = function ($msg) : void {
-            //check the db before running anything
-            $this->reconnectDb();
+        $sentryClient = SentrySdk::getCurrentHub()->getClient();
 
-            //we get the data from our event trigger and unserialize
-            $event = unserialize($msg->body);
+        $callback = function ($msg) use ($sentryClient) : void {
+            try {
+                //check the db before running anything
+                $this->reconnectDb();
 
-            //overwrite the user who is running this process
-            if (isset($event['userData']) && $event['userData'] instanceof Users) {
-                $this->di->setShared('userData', $event['userData']);
+                //we get the data from our event trigger and unserialize
+                $event = unserialize($msg->body);
+
+                //overwrite the user who is running this process
+                if (isset($event['userData']) && $event['userData'] instanceof Users) {
+                    $this->di->setShared('userData', $event['userData']);
+                }
+
+                //lets fire the event
+                $this->events->fire($event['event'], $event['source'], $event['data']);
+
+                $this->log->info(
+                    "Notification ({$event['event']}) - Process ID " . $msg->delivery_info['consumer_tag']
+                );
+            } catch (Throwable $e) {
+                $this->log->error(
+                    $e->getMessage(),
+                    [
+                        $e->getTraceAsString(),
+                    ]
+                );
+
+                $sentryClient->flush();
             }
-
-            //lets fire the event
-            $this->events->fire($event['event'], $event['source'], $event['data']);
-
-            $this->log->info(
-                "Notification ({$event['event']}) - Process ID " . $msg->delivery_info['consumer_tag']
-            );
         };
 
         Queue::process(QUEUE::EVENTS, $callback);
@@ -60,47 +73,59 @@ class QueueTask extends PhTask
      */
     public function notificationsAction()
     {
-        $callback = function (object $msg) : void {
-            //check the db before running anything
-            $this->reconnectDb();
+        $sentryClient = SentrySdk::getCurrentHub()->getClient();
 
-            //we get the data from our event trigger and unserialize
-            $notification = unserialize($msg->body);
+        $callback = function (object $msg) use ($sentryClient) : void {
+            try {
+                //check the db before running anything
+                $this->reconnectDb();
 
-            //overwrite the user who is running this process
-            if ($notification['from'] instanceof Users) {
-                $this->di->setShared('userData', $notification['from']);
+                //we get the data from our event trigger and unserialize
+                $notification = unserialize($msg->body);
+
+                //overwrite the user who is running this process
+                if ($notification['from'] instanceof Users) {
+                    $this->di->setShared('userData', $notification['from']);
+                }
+
+                if (!$notification['to'] instanceof Users) {
+                    echo 'Attribute TO has to be a User' . PHP_EOL;
+                    return;
+                }
+
+                if (!class_exists($notification['notification'])) {
+                    echo 'Attribute notification has to be a Notification' . PHP_EOL;
+                    return;
+                }
+                $notificationClass = $notification['notification'];
+
+                if (!$notification['entity'] instanceof Model) {
+                    echo 'Attribute entity has to be a Model' . PHP_EOL;
+                    return;
+                }
+
+                $user = $notification['to'];
+
+                //instance notification and pass the entity
+                $notification = new $notification['notification']($notification['entity']);
+                //disable the queue so we process it now
+                $notification->disableQueue();
+
+                //run notify for the specify user
+                $user->notify($notification);
+
+                $this->log->info(
+                    "Notification ({$notificationClass}) sent to {$user->email} - Process ID " . $msg->delivery_info['consumer_tag']
+                );
+            } catch (Throwable $e) {
+                $this->log->error(
+                    $e->getMessage(),
+                    [
+                        $e->getTraceAsString(),
+                    ]
+                );
+                $sentryClient->flush();
             }
-
-            if (!$notification['to'] instanceof Users) {
-                echo 'Attribute TO has to be a User' . PHP_EOL;
-                return;
-            }
-
-            if (!class_exists($notification['notification'])) {
-                echo 'Attribute notification has to be a Notification' . PHP_EOL;
-                return;
-            }
-            $notificationClass = $notification['notification'];
-
-            if (!$notification['entity'] instanceof Model) {
-                echo 'Attribute entity has to be a Model' . PHP_EOL;
-                return;
-            }
-
-            $user = $notification['to'];
-
-            //instance notification and pass the entity
-            $notification = new $notification['notification']($notification['entity']);
-            //disable the queue so we process it now
-            $notification->disableQueue();
-
-            //run notify for the specify user
-            $user->notify($notification);
-
-            $this->log->info(
-                "Notification ({$notificationClass}) sent to {$user->email} - Process ID " . $msg->delivery_info['consumer_tag']
-            );
         };
 
         Queue::process(QUEUE::NOTIFICATIONS, $callback);

--- a/src/Cli/Tasks/QueueTask.php
+++ b/src/Cli/Tasks/QueueTask.php
@@ -59,7 +59,9 @@ class QueueTask extends PhTask
                     ]
                 );
 
-                $sentryClient->flush();
+                if ($sentryClient) {
+                    $sentryClient->flush();
+                }
             }
         };
 
@@ -124,7 +126,10 @@ class QueueTask extends PhTask
                         $e->getTraceAsString(),
                     ]
                 );
-                $sentryClient->flush();
+
+                if ($sentryClient) {
+                    $sentryClient->flush();
+                }
             }
         };
 
@@ -186,7 +191,9 @@ class QueueTask extends PhTask
                             ]
                         );
 
-                        $sentryClient->flush();
+                        if ($sentryClient) {
+                            $sentryClient->flush();
+                        }
                     }
                 });
             } catch (Throwable $e) {
@@ -197,7 +204,9 @@ class QueueTask extends PhTask
                     ]
                 );
 
-                $sentryClient->flush();
+                if ($sentryClient) {
+                    $sentryClient->flush();
+                }
             }
         };
 


### PR DESCRIPTION
Version: The version of the package where the fix has been made.

Description:

All queues should send information to sentry , if configured

Features: To log all information