### PR TITLE
[0.3] Using integers for registered date claims is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "elasticsearch/elasticsearch": "^7.5",
         "firebase/php-jwt": "^5.0",
         "fzaninotto/faker": "^1.9@dev",
-        "lcobucci/jwt": "^3.2",
+        "lcobucci/jwt": "^3.3",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "league/fractal": "^0.17.0",


### PR DESCRIPTION
Version: The version of the package where the fix has been made.

Description:

Fix JWT Using integers for registered date claims is deprecated
